### PR TITLE
Create Remove leading zeroes in track number.csx

### DIFF
--- a/Remove leading zeroes in track number.csx
+++ b/Remove leading zeroes in track number.csx
@@ -1,0 +1,13 @@
+// This script removes the leading zeroes in the track number, the opposite of "Use two digits for track number.csx"
+
+using Metatogger.Data;
+using System;
+
+foreach	(var file in files)
+{
+	int trackNumber = Int32.Parse(file.GetFirstValue(TagName.TrackNumber));
+	if (trackNumber != null && trackNumber < 10)
+	{
+		file.SetTag(TagName.TrackNumber, $"{trackNumber}");
+	}
+}

--- a/Remove leading zeroes in track number.csx
+++ b/Remove leading zeroes in track number.csx
@@ -1,13 +1,10 @@
 // This script removes the leading zeroes in the track number, the opposite of "Use two digits for track number.csx"
-
-using Metatogger.Data;
 using System;
+using Metatogger.Data;
 
-foreach	(var file in files)
-{
-	int trackNumber = Int32.Parse(file.GetFirstValue(TagName.TrackNumber));
-	if (trackNumber != null && trackNumber < 10)
-	{
-		file.SetTag(TagName.TrackNumber, $"{trackNumber}");
-	}
+foreach(var file in files) {
+ int trackNumber;
+ if (Int32.TryParse(file.GetFirstValue(TagName.TrackNumber), out trackNumber)) {
+  file.SetTag(TagName.TrackNumber, $ "{trackNumber}");
+ }
 }


### PR DESCRIPTION
This script removes the leading zeroes in the track number, the opposite of "Use two digits for track number.csx"
Note: track number should be parseable by Int32.Parse (e.g. the String input "07", "02" etc.)