### PR TITLE
Ignore "/" when updating track numbers to 2 digits

### DIFF
--- a/Use two digits for track number.csx
+++ b/Use two digits for track number.csx
@@ -1,10 +1,25 @@
 // This script add a zero in front of track number if it is less than ten
 
 using Metatogger.Data;
+using System;
 
 foreach (var file in files)
 {
+	// Get the current track number
 	string trackNumber = file.GetFirstValue(TagName.TrackNumber);
+	if (trackNumber.Contains("/"))
+	{
+		// If track contains '/' (e.g. "1/10"), only takes the text before the "/"
+		int charLocation = trackNumber.IndexOf("/", StringComparison.Ordinal);
+		trackNumber = trackNumber.Substring(0, charLocation);
+	}
+	
+	// Adds leading zero
 	if (trackNumber != null && trackNumber.Length == 1)
-		file.SetTag(TagName.TrackNumber, $"0{trackNumber}");
+	{
+		trackNumber = $"0{trackNumber}";
+	}
+	
+	// Finally, sets the track number
+	file.SetTag(TagName.TrackNumber, trackNumber);
 }


### PR DESCRIPTION
## Firstly: Hello!

First of all, I want to say that this app is absolutely awesome and has given me a ton of joy to organize my music. It's really nicely done and I've cleaned up years of music. THANK YOU!

## Background
When utilizing the 2-digit track number script, I realized it had an error on some of my tracks with fractional track numbers (e.g. 1/10, 2/10, etc.)

## This PR

* Ignores text after the track number
* Adds some comments

## Testing

I've used this on ~5,000 songs while cleaning up my library and it hasn't failed once. 😄 